### PR TITLE
VSR will not delete roverbody v2 or XL model.

### DIFF
--- a/GameData/ChopShop/ModuleManager/final_fix_stock_rover.cfg
+++ b/GameData/ChopShop/ModuleManager/final_fix_stock_rover.cfg
@@ -7,10 +7,35 @@
 
 // Fixing stock part parameters
 
-@PART[roverBody|roverBody_v2]:FOR[ChopShop]
+@PART[roverBody]:FOR[ChopShop]
 {
 	@node_stack_bottom =  0.0, 0.0, -0.2241425, 0.0, 0.0, -1.0, 1
 	@node_stack_top =  0.0, 0.0, 0.2241425, 0.0, 0.0, 1.0, 1
+	@mass = 0.3
+	@vesselType = Rover
+	@tags = #autoLOC_500351 cck-rovers
+
+@RESOURCE[ElectricCharge]
+{
+	@amount = 400
+	@maxAmount = 400
+}
+MODULE
+ {
+	name = ModuleReactionWheel
+	PitchTorque = 1.5
+	YawTorque = 0.5
+	RollTorque = 1.5
+	RESOURCE
+	{
+		name = ElectricCharge
+		rate = 0.2
+	}
+ }
+}
+
+@PART[roverBody_v2]:FOR[ChopShop]
+{
 	@mass = 0.3
 	@vesselType = Rover
 	@tags = #autoLOC_500351 cck-rovers
@@ -38,7 +63,7 @@ MODULE
 
 @PART[roverBody]:FOR[ChopShop]:NEEDS[!VenStockRevamp]
 {
-!mesh
+!mesh = delete
 MODEL
  {
 	model = Squad/Parts/Command/probeRoverBody/model
@@ -53,15 +78,5 @@ MODEL
 @MODEL
 {
 	rotation = 90, 180, 0
-}
-}
-
-// Assuring Rover_XL recieves the same Ven's model.
-
-@PART[ChopShop_RoverXL]:NEEDS[VenStockRevamp]:AFTER[VenStockRevamp]
-{
-@MODEL
-{
-	@model = #$@PART[roverBody]/MODEL/model$	// Doesn't matter where Ven put that, he'll always change roverBody MODEL{}.
 }
 }


### PR DESCRIPTION
I can guarantee that because I'm the one updating it for KSP 1.5.
Also split v2 patch away from "v1" patch because the node placement patch only applied when the model was being rotated, which the new one is not.